### PR TITLE
Added additional quotes to image background rule

### DIFF
--- a/bg-lazyload.js
+++ b/bg-lazyload.js
@@ -93,7 +93,7 @@ BgLazyLoader.prototype.load = function() {
 };
 
 BgLazyLoader.prototype.onload = function( event ) {
-  this.element.style.backgroundImage = 'url(' + this.url + ')';
+  this.element.style.backgroundImage = 'url("' + this.url + '")';
   this.complete( event, 'flickity-bg-lazyloaded' );
 };
 


### PR DESCRIPTION
Given a specific image URL, the css backgroundImage rule might not work. 
Example of a URL I had trouble with:
```http://www.etrips.info/photo/large/Luxury-Apartment-Ljubljana_(16)1.jpg```

The image itself opens up normally in the browser and also works if added via the developer tools as a backgroundImage CSS rule.
I haven't been able to find or research the exact cause but my assumption is that the parentheses might be the culprits. 

Adding additional quotes to the backgroundImage rule resolves the issue.